### PR TITLE
Add context.Context to TProcessor and TProcessorFunction

### DIFF
--- a/lib/go/thrift/http_transport.go
+++ b/lib/go/thrift/http_transport.go
@@ -19,7 +19,10 @@
 
 package thrift
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // NewThriftHandlerFunc is a function that create a ready to use Apache Thrift Handler function
 func NewThriftHandlerFunc(processor TProcessor,
@@ -29,6 +32,6 @@ func NewThriftHandlerFunc(processor TProcessor,
 		w.Header().Add("Content-Type", "application/x-thrift")
 
 		transport := NewStreamTransport(r.Body, w)
-		processor.Process(inPfactory.GetProtocol(transport), outPfactory.GetProtocol(transport))
+		processor.Process(context.Background(), inPfactory.GetProtocol(transport), outPfactory.GetProtocol(transport))
 	}
 }

--- a/lib/go/thrift/multiplexed_protocol.go
+++ b/lib/go/thrift/multiplexed_protocol.go
@@ -20,6 +20,7 @@
 package thrift
 
 import (
+	"context"
 	"fmt"
 	"strings"
 )
@@ -127,7 +128,7 @@ func (t *TMultiplexedProcessor) RegisterProcessor(name string, processor TProces
 	t.serviceProcessorMap[name] = processor
 }
 
-func (t *TMultiplexedProcessor) Process(in, out TProtocol) (bool, TException) {
+func (t *TMultiplexedProcessor) Process(ctx context.Context, in, out TProtocol) (bool, TException) {
 	name, typeId, seqid, err := in.ReadMessageBegin()
 	if err != nil {
 		return false, err
@@ -140,7 +141,7 @@ func (t *TMultiplexedProcessor) Process(in, out TProtocol) (bool, TException) {
 	if len(v) != 2 {
 		if t.DefaultProcessor != nil {
 			smb := NewStoredMessageProtocol(in, name, typeId, seqid)
-			return t.DefaultProcessor.Process(smb, out)
+			return t.DefaultProcessor.Process(ctx, smb, out)
 		}
 		return false, fmt.Errorf("Service name not found in message name: %s.  Did you forget to use a TMultiplexProtocol in your client?", name)
 	}
@@ -149,7 +150,7 @@ func (t *TMultiplexedProcessor) Process(in, out TProtocol) (bool, TException) {
 		return false, fmt.Errorf("Service name not found: %s.  Did you forget to call registerProcessor()?", v[0])
 	}
 	smb := NewStoredMessageProtocol(in, v[1], typeId, seqid)
-	return actualProcessor.Process(smb, out)
+	return actualProcessor.Process(ctx, smb, out)
 }
 
 //Protocol that use stored message for ReadMessageBegin

--- a/lib/go/thrift/processor.go
+++ b/lib/go/thrift/processor.go
@@ -19,12 +19,14 @@
 
 package thrift
 
+import "context"
+
 // A processor is a generic object which operates upon an input stream and
 // writes to some output stream.
 type TProcessor interface {
-	Process(in, out TProtocol) (bool, TException)
+	Process(ctx context.Context, in, out TProtocol) (bool, TException)
 }
 
 type TProcessorFunction interface {
-	Process(seqId int32, in, out TProtocol) (bool, TException)
+	Process(ctx context.Context, seqId int32, in, out TProtocol) (bool, TException)
 }

--- a/lib/go/thrift/simple_server.go
+++ b/lib/go/thrift/simple_server.go
@@ -20,6 +20,7 @@
 package thrift
 
 import (
+	"context"
 	"log"
 	"runtime/debug"
 	"sync"
@@ -178,7 +179,7 @@ func (p *TSimpleServer) processRequests(client TTransport) error {
 		defer outputTransport.Close()
 	}
 	for {
-		ok, err := processor.Process(inputProtocol, outputProtocol)
+		ok, err := processor.Process(context.Background(), inputProtocol, outputProtocol)
 		if err, ok := err.(TTransportException); ok && err.TypeId() == END_OF_FILE {
 			return nil
 		} else if err != nil {


### PR DESCRIPTION
This adds a context.Context parameter to the TProcessor and TProcessorFunction interfaces for request-scoped context propagation.